### PR TITLE
Update PagSeguroClient.php

### DIFF
--- a/src/Giovannefc/PagSeguro/PagSeguroClient.php
+++ b/src/Giovannefc/PagSeguro/PagSeguroClient.php
@@ -29,7 +29,11 @@ class PagSeguroClient extends PagSeguroConfig
         curl_setopt($ch, CURLOPT_POST, count($credentials));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // para testar em http. Para https, setar para true!
+        if(app()->environment() == 'production') {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); 
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
 
         $result = curl_exec($ch);
         
@@ -72,7 +76,11 @@ class PagSeguroClient extends PagSeguroConfig
         curl_setopt($ch, CURLOPT_POST, count($settings));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // para testar em http. Para https, setar para true!
+        if(app()->environment() == 'production') {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); 
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
 
         $result = simplexml_load_string(curl_exec($ch));
 

--- a/src/Giovannefc/PagSeguro/PagSeguroClient.php
+++ b/src/Giovannefc/PagSeguro/PagSeguroClient.php
@@ -29,8 +29,12 @@ class PagSeguroClient extends PagSeguroConfig
         curl_setopt($ch, CURLOPT_POST, count($credentials));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // para testar em http. Para https, setar para true!
 
         $result = curl_exec($ch);
+        
+        if (FALSE === $result)
+            throw new PagSeguroException(curl_error($ch), curl_errno($ch));
 
         if ($result == 'Unauthorized' || $result == 'Forbidden') {
             throw new PagSeguroException($result . ': Provavelmente você precisa solicitar a liberação do pagamento transparente em sua conta.', 1);
@@ -68,6 +72,7 @@ class PagSeguroClient extends PagSeguroConfig
         curl_setopt($ch, CURLOPT_POST, count($settings));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // para testar em http. Para https, setar para true!
 
         $result = simplexml_load_string(curl_exec($ch));
 


### PR DESCRIPTION
Giovanne, trabalho excelente! 
Muito obrigado!

Ao tentar implementar no Laravel 5.2, recebi um erro relacionado à primeira linha do arquivo js.blade.php. {!! PagSeguro::jsSetSessionId() !!} :

_**ErrorException in PagSeguroClient.php line 45: Trying to get property of non-object (View: C:\xampp\htdocs\_tml\resources\views\home.blade.php)**_

Então, investigando mais a fundo, fui até a classe PagSeguroClient.php, que é onde acontecia o erro, e percebi o seguinte: Na linha 33, a variável $result está retornando FALSE e não existe uma verificação de erro para este caso. Então, eu adicionei o seguinte:

**if (FALSE === $result)
            throw new PagSeguroException(curl_error($ch), curl_errno($ch));**

Fazendo isso, ao dar um refresh na página, o erro que me foi exibido foi o seguinte:
**PagSeguroException in PagSeguroClient.php line 39: SSL certificate problem: self signed certificate in certificate chain** 

Neste caso, o problema ocorre devido ao fato de eu estar usando XAMPP Server e HTTP em ambiente local e não HTTPS em ambiente de produção.

Para resolver, adicionei a seguinte linha logo abaixo do curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1): 

**curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);** 
_**Importante:**_ manter essa linha apenas para testar em http e ambiente local. Para ambiente de produção e https, setar para true ou remove-la!

Outro detalhe é que o valor das parcelas do cartão estão em formato errado, isso também está apontando um erro, já que o PagSeguro exige 2 dígitos decimais nesse caso.
Por exemplo: number_format($price, '2', '.', ''); //ex: 10.00

Feito isso, bastou apenas formatar todos os dados corretamente e seguir com o seu exemplo.
Funcionando perfeitamente aqui. 

Novamente, agradeço a você pela iniciativa e parabéns pelo trabalho.

Até!